### PR TITLE
Use pkgconf to reliably lookup libbsd include and library paths

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Install packages
-      run: sudo apt-get -y install libbsd-dev libevent-dev
+      run: sudo apt-get -y install libbsd-dev libevent-dev pkgconf
     - name: Checkout sources
       uses: actions/checkout@v3
     - name: Make build

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,8 +1,7 @@
-CFLAGS+=	-D_DEFAULT_SOURCE -D_GNU_SOURCE \
-		-DLIBBSD_OVERLAY -isystem /usr/include/bsd \
-		-isystem /usr/local/include/bsd \
-		-Wall
-LDFLAGS+=	-lbsd -levent -lm
+CFLAGS+=	-D_DEFAULT_SOURCE -D_GNU_SOURCE -Wall \
+		$(shell pkgconf --cflags libbsd-overlay)
+LDFLAGS+=	-levent -lm \
+		$(shell pkgconf --libs libbsd-overlay)
 BINDIR?=        /usr/local/bin
 MANDIR?=        /usr/local/man/man
 


### PR DESCRIPTION
via the libbsd-overlay library as documented in libbsd(7).

From the man page:

> The library can be used in an overlay mode, which is the preferred way, so that the code is portable and requires no modification to the original BSD code. This can be done easily with the [pkgconf(1)](https://man.archlinux.org/man/pkgconf.1.en) library named libbsd-overlay. Or by adding the system-specific include directory with the bsd/ suffix to the list of system include paths. With gcc this could be -isystem ${includedir}/bsd. In addition the LIBBSD_OVERLAY pre-processor variable needs to be defined. The includes in this case should be the usual system ones, such as <unistd.h>.

This is needed in Debian where the include and library paths may include arch triplets for multi-arch installations and fixes https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1066558