### PR TITLE
Zap DESTDIR from GNUmakefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,8 +17,8 @@ clean:
 	rm -f tcpbench tcpbench.o out *.crt *.key *.req *.srl
 
 install:
-	install -c -m 555 -s tcpbench -D -t ${DESTDIR}${BINDIR}
-	install -c -m 444 tcpbench.1 -D -t ${DESTDIR}${MANDIR}1
+	install -c -m 555 -s tcpbench -D -t ${BINDIR}
+	install -c -m 444 tcpbench.1 -D -t ${MANDIR}1
 
 .PHONY: test test-localhost test-localhost6 test-tls test-ciphers
 test: test-localhost test-localhost6 test-tls test-ciphers


### PR DESCRIPTION
BINDIR and MANDIR already express the full path.

-- 

ohai o/

I think this was unintended judging by the way BINDIR and MANDIR are defined, debian also doesn't use it.